### PR TITLE
Casting 'numeric values' to int before casting to boolean in surface

### DIFF
--- a/lib/configs/surface.py
+++ b/lib/configs/surface.py
@@ -148,8 +148,8 @@ class AC_Surface(PropertyGroup):
         self.wav_pitch = float(data["WAV_PITCH"]) if "WAV_PITCH" in data else 1
         self.ff_effect = f'{data["FF_EFFECT"]}' if "FF_EFFECT" in data else ""
         self.dirt_additive = float(data["DIRT_ADDITIVE"]) if "DIRT_ADDITIVE" in data else 0
-        self.is_pit_lane = bool(data["IS_PITLANE"]) if "IS_PITLANE" in data else False
-        self.is_valid_track = bool(data["IS_VALID_TRACK"]) if "IS_VALID_TRACK" in data else True
+        self.is_pit_lane = bool(int(data["IS_PITLANE"])) if "IS_PITLANE" in data else False
+        self.is_valid_track = bool(int(data["IS_VALID_TRACK"])) if "IS_VALID_TRACK" in data else True
         self.black_flag_time = int(data["BLACK_FLAG_TIME"]) if "BLACK_FLAG_TIME" in data else 0
         self.sin_height = float(data["SIN_HEIGHT"]) if "SIN_HEIGHT" in data else 0
         self.sin_length = float(data["SIN_LENGTH"]) if "SIN_LENGTH" in data else 0


### PR DESCRIPTION
Very small change. 

Problem: 
Surface type ROAD (in fact any) always read back is_pitlane = True. 
Was annoying when iterating on the track, because it was overwritten everytime on export.

Solution: 
proper casting of boolean values 

Comment:
Hey, I don't understand pythons implicit type behavior enough to explain why this happened, but fact is that boolean values in surfaces.ini and perhaps elsewhere are interpreted wrong (always True). 
We need to cast it 'explicitly' to **numeric type int** before casting it to a **boolean**. 
Otherwise python does python things...

I'm very happy when I learn new things, so enlighten me if you understand the 'why'

kudos
Michael